### PR TITLE
Fix quadratic algorithm for sorting menu items

### DIFF
--- a/siduction-btrfs-0.1.0/09_siduction-btrfs
+++ b/siduction-btrfs-0.1.0/09_siduction-btrfs
@@ -283,9 +283,15 @@ EOF
 # yet, so it's empty. In a submenu it will be equal to '\t' (one tab).
 submenu_indentation=""
 
+# Perform a reverse version sort on the entire list.
+# Temporarily replace the '.old' suffix by ' 1' and append ' 2' for all
+# other files to order the '.old' files after their non-old counterpart
+# in reverse-sorted order.
+
+reverse_sorted_list=$(echo $list | tr ' ' '\n' | sed -e 's/\.old$/ 1/; / 1$/! s/$/ 2/' | version_sort -r | sed -e 's/ 1$/.old/; s/ 2$//')
+
 is_top_level=true
-while [ "x$list" != "x" ] ; do
-  linux=`version_find_latest $list`
+for linux in ${reverse_sorted_list}; do
   case $linux in
     *.efi.signed)
       # We handle these in linux_entry.
@@ -381,7 +387,6 @@ while [ "x$list" != "x" ] ; do
                 "${GRUB_CMDLINE_LINUX_RECOVERY} ${GRUB_CMDLINE_LINUX}"
   fi
 
-  list=`echo $list | tr ' ' '\n' | fgrep -vx "$linux" | tr '\n' ' '`
 done
 
 # If at least one kernel was found, then we need to


### PR DESCRIPTION
This implements grub.git commit 99e05ab555f013b5ce45a3fd04f8ccd5f4e5bf95 
https://git.savannah.gnu.org/cgit/grub.git/commit/?id=99e05ab555f013b5ce45a3fd04f8ccd5f4e5bf95

The latest grub-pc update breaks with the following error:

```
Setting up grub-pc (2.12~rc1-7) ...
Generating grub configuration file ...
Found theme: /usr/share/grub/themes/giants/theme.txt
/etc/grub.d/09_siduction-btrfs: 1: version_find_latest: not found
dpkg: error processing package grub-pc (--configure):
 installed grub-pc package post-installation script subprocess returned error exit status 127
Errors were encountered while processing:
 grub-pc
```

It seems this is due to the deprecation of `version_find_latest()`.  Porting this commit from grub fixes the problem.
